### PR TITLE
Rename subtitle files with language code

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -193,13 +193,15 @@ def GetFiles(part):
             sSrtName = sSrtName.decode('utf-8')
             sTest = sIsValid(sMyDir, sFile, sSrtName)
             if sTest != 'null':
+                # Got a language code in the file-name?
+                sMyLang = sGetFileLang(sTest)
+                if sMyLang == 'xx':
+                    sMyLang = GetUsrEncPref()
+                    sMyLang = Locale.Language.Match(sMyLang)
+                    RenameSubtitlesWithLanguage(sTest, sMyLang)
+                
                 # We got a valid subtitle file here
                 if not bIsUTF_8(sTest):
-                    # Got a language code in the file-name?
-                    sMyLang = sGetFileLang(sTest)
-                    if sMyLang == 'xx':
-                        sMyLang = GetUsrEncPref()
-                        sMyLang = Locale.Language.Match(sMyLang)
                     FixFile(sTest, sMyLang)
                 else:
                     strLog = ''.join((
@@ -208,6 +210,16 @@ def GetFiles(part):
                         ' is already encoded in utf-8, so skipping'
                     ))
                     Log.Debug(strLog)
+
+def RenameSubtitlesWithLanguage(myFile, sMyLang):
+    if Prefs['ConversionResult']:
+        fileName, fileExtension = os.path.splitext(myFile)
+        sTarget = fileName + ‘.’ + sMyLang + fileExtension
+        Log.Debug('Original file %s renamed to %s' %(myFile, sTarget))
+        os.rename(myFile, sTarget)
+        return sTarget
+    else:
+        return myFile
 
 
 def ConvertFile(myFile, enc):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -220,11 +220,14 @@ def GetFiles(part):
                         Log.Debug(strLog)
 
 def RenameSubtitlesWithLanguage(myFile, sMyLang):
-    fileName, fileExtension = os.path.splitext(myFile)
-    sTarget = fileName + '.' + sMyLang + fileExtension
-    os.rename(myFile, sTarget)
-    Log.Debug('Renaming: From %s to %s' %(myFile, sTarget))
-    return sTarget
+    if Prefs['PreferredCP'] != 'None' and sMyLang != 'xx':
+        fileName, fileExtension = os.path.splitext(myFile)
+        sTarget = fileName + '.' + sMyLang + fileExtension
+        os.rename(myFile, sTarget)
+        Log.Debug('Renaming: From %s to %s' %(myFile, sTarget))
+        return sTarget
+    else:
+        return myFile
 
 
 def ConvertFile(myFile, enc):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -125,17 +125,19 @@ def GetOSSrt(part):
                         sFileName, sFileExtension = os.path.splitext(sSrtName)
                         # Is this a backup file?
                         if sFileExtension != '.Srt2Utf-8':
-                            # Nope, so go ahead
-                            Log.Debug('Checking file: %s' % (sMySrtFile))
-                            if not bIsUTF_8(sMySrtFile):
-                                strLogEntry = ''.join((
-                                    '****** File is not UTF-8',
-                                    '...Need to fix it *******'
-                                ))
-                                Log.Debug(strLogEntry)
-                                FixFile(sMySrtFile, langCode)
-                            else:
-                                Log.Debug('File is okay')
+                            # Only fix the subtitle file encoding if setting is enabled
+                            if Prefs['Fix_Subtitle_Encoding']:
+                                # Nope, so go ahead
+                                Log.Debug('Checking file: %s' % (sMySrtFile))
+                                if not bIsUTF_8(sMySrtFile):
+                                    strLogEntry = ''.join((
+                                        '****** File is not UTF-8',
+                                        '...Need to fix it *******'
+                                    ))
+                                    Log.Debug(strLogEntry)
+                                    FixFile(sMySrtFile, langCode)
+                                else:
+                                    Log.Debug('File is okay')
 
 
 def FixFile(sFile, sMyLang):
@@ -202,17 +204,19 @@ def GetFiles(part):
 
                     if Prefs['Add_Language_Code']:
                         sTest = RenameSubtitlesWithLanguage(sTest, sMyLang)
-                    
-                # We got a valid subtitle file here
-                if not bIsUTF_8(sTest):
-                    FixFile(sTest, sMyLang)
-                else:
-                    strLog = ''.join((
-                        'The subtitle file named : ',
-                        '%s' % (sTest),
-                        ' is already encoded in utf-8, so skipping'
-                    ))
-                    Log.Debug(strLog)
+
+                # Only fix the subtitle file encoding if setting is enabled
+                if Prefs['Fix_Subtitle_Encoding']:
+                    # We got a valid subtitle file here
+                    if not bIsUTF_8(sTest):
+                        FixFile(sTest, sMyLang)
+                    else:
+                        strLog = ''.join((
+                            'The subtitle file named : ',
+                            '%s' % (sTest),
+                            ' is already encoded in utf-8, so skipping'
+                        ))
+                        Log.Debug(strLog)
 
 def RenameSubtitlesWithLanguage(myFile, sMyLang):
     fileName, fileExtension = os.path.splitext(myFile)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -193,13 +193,16 @@ def GetFiles(part):
             sSrtName = sSrtName.decode('utf-8')
             sTest = sIsValid(sMyDir, sFile, sSrtName)
             if sTest != 'null':
-                # Got a language code in the file-name?
+                # Got a language code in the file-name? If not, add language code to file-name.
                 sMyLang = sGetFileLang(sTest)
                 if sMyLang == 'xx':
+                    Log.Debug('No language code detected for the file: %s' %(sTest))
                     sMyLang = GetUsrEncPref()
                     sMyLang = Locale.Language.Match(sMyLang)
-                    RenameSubtitlesWithLanguage(sTest, sMyLang)
-                
+
+                    if Prefs['Add_Language_Code']:
+                        sTest = RenameSubtitlesWithLanguage(sTest, sMyLang)
+                    
                 # We got a valid subtitle file here
                 if not bIsUTF_8(sTest):
                     FixFile(sTest, sMyLang)
@@ -212,14 +215,11 @@ def GetFiles(part):
                     Log.Debug(strLog)
 
 def RenameSubtitlesWithLanguage(myFile, sMyLang):
-    if Prefs['ConversionResult']:
-        fileName, fileExtension = os.path.splitext(myFile)
-        sTarget = fileName + ‘.’ + sMyLang + fileExtension
-        Log.Debug('Original file %s renamed to %s' %(myFile, sTarget))
-        os.rename(myFile, sTarget)
-        return sTarget
-    else:
-        return myFile
+    fileName, fileExtension = os.path.splitext(myFile)
+    sTarget = fileName + '.' + sMyLang + fileExtension
+    os.rename(myFile, sTarget)
+    Log.Debug('Renaming: From %s to %s' %(myFile, sTarget))
+    return sTarget
 
 
 def ConvertFile(myFile, enc):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,9 +1,10 @@
-# Convert sidecar subtitle files files into UTF-8 format
+# Convert sidecar subtitle files files into UTF-8 format, and add language code to end of subtitle file names
 # Created by dane22, a Plex community member
 #
 # Code contributions made by the following:
 # srazer, also a Plex community member
 # jmichiel, also a Plex community member
+# haarismemon, also a Plex community member
 #
 
 # TODO:
@@ -27,7 +28,7 @@ from chared.detector import list_models, get_model_path, EncodingDetector
 
 
 # ############################ Global Variables ###################
-PLUGIN_VERSION = '0.0.2.5'
+PLUGIN_VERSION = '0.0.3'
 
 
 def Start():

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,5 +1,11 @@
 [
 	{
+		"id": "Fix_Subtitle_Encoding",
+		"label": "Fix Subtitle Encoding (disabling this means this plugin will no longer do its main purpose)",
+		"type": "bool",
+		"default": "true"
+	},
+	{
 		"id": "Make_Backup",
 		"label": "Create backup",
 		"type": "bool",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -46,6 +46,12 @@
 			"Uighur","Ukrainian","Urdu","Uzbek","Venda","Vietnamese","Walloon","Welsh","Wolof",
 			"Xhosa","Yiddish","Yoruba","Zhuang","Zulu"],
 		"default": "None"
+	},
+	{
+		"id": "Add_Language_Code",
+		"label": "Add language code to subtitle files if not present (You must select your preferred language before enabling this setting)",
+		"type": "bool",
+		"default": "false"
 	}
-	
+
 ]

--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -7,7 +7,8 @@
 	<key>PlexAgentAttributionText</key>
 	<string>
 		The main purpose of the &lt;a href=&quot;http://forums.plex.tv/discussion/94864/rel-str2utf-8/p1#top&quot;&gt;srt2utf-8&lt;/a&gt; agent is to make sure, &lt;br/&gt;
-		that all not embedded subtitle files are encoded as UTF-8.&lt;br/&gt; For the manual, please look &lt;a href=&quot;https://github.com/ukdtom/SRT2UTF-8.bundle/wiki/&quot;&gt;here&lt;/a&gt;	</string>
+		that all not embedded subtitle files are encoded as UTF-8. The agent, additionally, renames subtitle files by appending the language code, if missing.
+		&lt;br/&gt; For the manual, please look &lt;a href=&quot;https://github.com/ukdtom/SRT2UTF-8.bundle/wiki/&quot;&gt;here&lt;/a&gt;	</string>
 	<key>PlexFrameworkVersion</key>
 	<string>2</string>
 	<key>PlexPluginClass</key>

--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@ SRT2UTF-8.bundle
 
 ***
 
-Plex Agent, that'll convert sidecar subtitle files into UTF-8, if not
+A Plex Agent that will convert sidecar subtitle files into UTF-8, if not already; and rename subtitle file names by appending a language code to the end. 
 
-Please read the Wiki for futher information
+The language code that is appended can be configured in the settings of the Plex Agent. Additionally, both the encoding to UTF-8 and the subtitle file renaming can be optionally turned off in the settings.
+
+Please read the Wiki for futher information:
 
 https://github.com/ukdtom/SRT2UTF-8.bundle/wiki
+
+## Note
+
+Please choose your preferred language before enabling the renaming of subtitle files. If the preferred language is set to None and the renaming is enabled, the language code that is appended will be 'xx'.
 
 WARNING!!!!!
 
@@ -18,4 +24,8 @@ It is important that you read the Wiki, since this agent will do what no other a
 
 Use at own risk
 
+## License
 
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ https://github.com/ukdtom/SRT2UTF-8.bundle/wiki
 
 ## Note
 
-Please choose your preferred language before enabling the renaming of subtitle files. If the preferred language is set to None and the renaming is enabled, the language code that is appended will be 'xx'.
+The renaming of subtitle files is disabled by default. This can be enabled in the Agent's settings for your Plex Server.
+
+Please select your preferred language before enabling the renaming of subtitle files. If the renaming is enabled and the language is not selected, the subtitle file names will remain unchanged.
 
 WARNING!!!!!
 
-It is important that you read the Wiki, since this agent will do what no other agent does in the Plex Universe, and that's changing your media files
+It is important that you read the Wiki, since this agent will do what no other agent does in the Plex Universe, and that's changing your media files.
 
-Use at own risk
+Use at own risk.
 
 ## License
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+v0.0.3.0:
+- Add new setting to optionally turn off the changing of subtitle file encoding to UTF-8.
+- Add new setting to optionally rename subtitle files by appending the user's preferred language code to the end, if not there already.
+
 v0.0.2.5:
 - Fixed #40
 


### PR DESCRIPTION
Hey! I love your Plex plugin. I was thinking it would be great if it could also add the language code to my subtitle files if they don't have one. So I had a little play around and it got it all working, and it is working really nicely.

I was thinking that it would be great if this could be added to this original project if you like it. If you have any comments or suggestions, I am open to it.

The changes are that:

- I've added two new settings: Optionally turn off subtitle encoding (if a user just wants to rename subtitles), and optionally turn on subtitle file renaming.
- When the setting for renaming subtitle is enabled, then when the language code is missing from a subtitle file (when it is 'xx'), then the user's preferred language code is added to the end of the subtitle file name. So the format would be: subtitle name + language code + .srt
- Updated the version number to 0.0.3