### PR TITLE
Add option to keep original file after adding language code

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -223,8 +223,14 @@ def RenameSubtitlesWithLanguage(myFile, sMyLang):
     if Prefs['PreferredCP'] != 'None' and sMyLang != 'xx':
         fileName, fileExtension = os.path.splitext(myFile)
         sTarget = fileName + '.' + sMyLang + fileExtension
-        os.rename(myFile, sTarget)
-        Log.Debug('Renaming: From %s to %s' %(myFile, sTarget))
+
+        if Prefs['Remove_Original_File']:
+            os.rename(myFile, sTarget)
+            Log.Debug('Renaming: From %s to %s' %(myFile, sTarget))
+        else:
+            shutil.copyfile(myFile, sTarget)
+            Log.Debug('Copying: From %s to %s' %(myFile, sTarget))
+
         return sTarget
     else:
         return myFile

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -58,6 +58,12 @@
 		"label": "Add language code to subtitle files if not present (You must select your preferred language before enabling this setting)",
 		"type": "bool",
 		"default": "false"
+	},
+	{
+		"id": "Remove_Original_File",
+		"label": "Remove the original subtitle file after adding the language code (Only takes effect if the \"Add language code\" option is also enabled)",
+		"type": "bool",
+		"default": "true"
 	}
 
 ]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The renaming of subtitle files is disabled by default. This can be enabled in th
 
 Please select your preferred language before enabling the renaming of subtitle files. If the renaming is enabled and the language is not selected, the subtitle file names will remain unchanged.
 
+Subtitle file renaming is also impacted by the "Remove the original subtitle file" option which is enabled by default. If disabled, the agent will copy the subtitle file instead of moving (renaming) it, leaving the original file in place.
+
 WARNING!!!!!
 
 It is important that you read the Wiki, since this agent will do what no other agent does in the Plex Universe, and that's changing your media files.


### PR DESCRIPTION
This commit expands on the work done in 14c2f1bc24efeb5fe5a67d6e11a4c4ec4185f2e3 by adding an option to configure whether the original subtitle file is removed after the language code is appended to the filename.

Default this to true to maintain backwards compatibility.

This option is useful when the subtitles operated on by SRT2UTF-8 are part of torrents still being seeded. By setting the new option to false, we don't tamper with the original subtitle file and we ensure that the torrent checksum does not change.